### PR TITLE
Adds social.lol, a private instance managed by omg.lol to the servers list

### DIFF
--- a/reference/servers.txt
+++ b/reference/servers.txt
@@ -63,6 +63,7 @@ sfba.social
 socel.net
 social.bau-ha.us
 social.linux.pizza
+social.lol
 social.vivaldi.net
 sself.co
 tech.lgbt


### PR DESCRIPTION
Not sure if the servers.txt list has anything to do with the published Chrome extension, but adding social.lol to it as a way to either provide the fix or kick off a polite request of the maintainer. 

social.lol is a private instance managed by <https://omg.lol>.